### PR TITLE
feat: 게시글 조회 시 postId도 리턴하도록 쿼리/Dto 수정

### DIFF
--- a/backend/src/main/java/com/example/delivery/dto/PostListDto.java
+++ b/backend/src/main/java/com/example/delivery/dto/PostListDto.java
@@ -3,12 +3,12 @@ package com.example.delivery.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class PostListDto {
+    private Long postId;
     private String createdAt;
     private String restaurant;
     private String menu;

--- a/backend/src/main/java/com/example/delivery/entity/Post.java
+++ b/backend/src/main/java/com/example/delivery/entity/Post.java
@@ -17,7 +17,7 @@ import lombok.*;
 @NamedNativeQueries({
         @NamedNativeQuery(
                 name = "Post.findPostList",
-                query = "SELECT p.created_at, p.restaurant, p.menu, p.price, p.part_num, u.nickname, p.is_valid " +
+                query = "SELECT p.post_id p.created_at, p.restaurant, p.menu, p.price, p.part_num, u.nickname, p.is_valid " +
                         "FROM post p " +
                         "JOIN user u ON p.user_id = u.id",
                 resultSetMapping = "postListMapper"
@@ -60,6 +60,7 @@ import lombok.*;
                 classes = @ConstructorResult(
                         targetClass = PostListDto.class,
                         columns = {
+                                @ColumnResult(name="post_id", type=Long.class),
                                 @ColumnResult(name="created_at", type=String.class),
                                 @ColumnResult(name="restaurant", type=String.class),
                                 @ColumnResult(name="menu", type=String.class),

--- a/backend/src/main/java/com/example/delivery/entity/Post.java
+++ b/backend/src/main/java/com/example/delivery/entity/Post.java
@@ -17,7 +17,7 @@ import lombok.*;
 @NamedNativeQueries({
         @NamedNativeQuery(
                 name = "Post.findPostList",
-                query = "SELECT p.post_id p.created_at, p.restaurant, p.menu, p.price, p.part_num, u.nickname, p.is_valid " +
+                query = "SELECT p.post_id, p.created_at, p.restaurant, p.menu, p.price, p.part_num, u.nickname, p.is_valid " +
                         "FROM post p " +
                         "JOIN user u ON p.user_id = u.id",
                 resultSetMapping = "postListMapper"
@@ -46,11 +46,11 @@ import lombok.*;
         ),
         @NamedNativeQuery(
                 name = "Post.findPostListInMyPage",
-                query = "SELECT p.created_at, p.restaurant, p.menu, p.price, p.part_num, u.nickname, p.is_valid " +
+                query = "SELECT p.post_id, p.created_at, p.restaurant, p.menu, p.price, p.part_num, u.nickname, p.is_valid " +
                         "FROM post p " +
                         "INNER JOIN user u ON p.user_id = u.id " +
                         "INNER JOIN participant pr ON p.post_id = pr.post_post_id " +
-                        "WHERE pr.user_id = 2;",
+                        "WHERE pr.user_id = :userId",
                 resultSetMapping = "postListMapper"
         )
 })


### PR DESCRIPTION
# Task Summary (*필수)
프론트엔드 요청으로 게시글 조회 시 postId도 리턴하도록 쿼리와 Dto를 수정했습니다.

# Changes (*필수)
* PostListDto - postId 필드를 추가
* Post - Post.findPostList 네이티브쿼리 수정, postListMapper ColumnResult에 post_id 추가 

# PR 유형 (*필수)
- [ ] Bug Fix (fix)
- [X] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)

# Screenshot

# Reference
