### PR TITLE
feat: 댓글 조회 시 commentId도 리턴하도록 쿼리/Dto 수정

### DIFF
--- a/backend/src/main/java/com/example/delivery/dto/CommentListDto.java
+++ b/backend/src/main/java/com/example/delivery/dto/CommentListDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CommentListDto {
+    private Long commentId;
     private String nickname;
     private String commentBody;
     private String createdAt;

--- a/backend/src/main/java/com/example/delivery/entity/Comment.java
+++ b/backend/src/main/java/com/example/delivery/entity/Comment.java
@@ -13,7 +13,7 @@ import lombok.*;
 @Getter
 @NamedNativeQuery(
         name = "Comment.findCommentList",
-        query = "SELECT u.nickname, c.comment_body, c.created_at " +
+        query = "SELECT c.comment_id, u.nickname, c.comment_body, c.created_at " +
                 "FROM comment c " +
                 "JOIN user u ON c.user_id = u.id " +
                 "WHERE c.post_post_id = :postId",
@@ -24,6 +24,7 @@ import lombok.*;
         classes = @ConstructorResult(
                 targetClass = CommentListDto.class,
                 columns = {
+                        @ColumnResult(name = "comment_id",type = Long.class),
                         @ColumnResult(name = "nickname",type = String.class),
                         @ColumnResult(name = "comment_body",type = String.class),
                         @ColumnResult(name = "created_at", type = String.class)


### PR DESCRIPTION
# Task Summary (*필수)
댓글 조회 시에 commentId도 함께 보내 프엔에서 사용할 수 있도록 수정했습니다.

# Changes (*필수)
* Comment - 네이티브쿼리 수정
* CommentListDto - Long commentId 추가

# PR 유형 (*필수)
- [X] Bug Fix (fix)
- [X] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)

# Screenshot

# Reference
